### PR TITLE
Fix non isosceles triangle case for right_triangle with ORIENT_Z

### DIFF
--- a/shapes.scad
+++ b/shapes.scad
@@ -343,29 +343,23 @@ module right_triangle(size=[1, 1, 1], orient=ORIENT_Y, anchor=ALLNEG, center=und
 		if (orient == ORIENT_X) {
 			ang = atan2(size.y, size.z);
 			masksize = [size.x, size.y, norm([size.y,size.z])] + [1,1,1];
-			xrot(ang) {
-				difference() {
-					xrot(-ang) cube(size, center=true);
-					back(masksize.y/2) cube(masksize, center=true);
-				}
+			difference() {
+				cube(size, center=true);
+				xrot(ang) back(masksize.y/2) cube(masksize, center=true);
 			}
 		} else if (orient == ORIENT_Y) {
 			ang = atan2(size.x, size.z);
 			masksize = [size.x, size.y, norm([size.x,size.z])] + [1,1,1];
-			yrot(-ang) {
-				difference() {
-					yrot(ang) cube(size, center=true);
-					right(masksize.x/2) cube(masksize, center=true);
-				}
+			difference() {
+				cube(size, center=true);
+				yrot(-ang) right(masksize.x/2) cube(masksize, center=true);
 			}
 		} else if (orient == ORIENT_Z) {
 			ang = atan2(size.x, size.y);
 			masksize = [size.y, norm([size.x,size.y]), size.z] + [1,1,1];
-			zrot(ang) {
-				difference() {
-					zrot(-ang) cube(size, center=true);
-					right(masksize.x/2) cube(masksize, center=true);
-				}
+			difference() {
+				cube(size, center=true);
+				zrot(ang) right(masksize.x/2) cube(masksize, center=true);
 			}
 		}
 		children();

--- a/shapes.scad
+++ b/shapes.scad
@@ -360,11 +360,11 @@ module right_triangle(size=[1, 1, 1], orient=ORIENT_Y, anchor=ALLNEG, center=und
 			}
 		} else if (orient == ORIENT_Z) {
 			ang = atan2(size.x, size.y);
-			masksize = [norm([size.x,size.y]), size.y, size.z] + [1,1,1];
-			zrot(-ang) {
+			masksize = [size.y, norm([size.x,size.y]), size.z] + [1,1,1];
+			zrot(ang) {
 				difference() {
-					zrot(ang) cube(size, center=true);
-					back(masksize.y/2) cube(masksize, center=true);
+					zrot(-ang) cube(size, center=true);
+					right(masksize.x/2) cube(masksize, center=true);
 				}
 			}
 		}


### PR DESCRIPTION
Hi there,

The first commit should fix the broken `ORIENT_Z` parameter for `right_triangle` when the triangle is not isosceles (when `width` isn't equal to `thickness`).
The second commit remove some redundancy, but feel free to discard it if you don't like it.

Test code: `right_triangle([60, 10, 40], orient=ORIENT_Z) frame_ref();`
Before: ![before](https://user-images.githubusercontent.com/3048933/57975448-9bc0c500-79c9-11e9-80e6-f4f8a9f7b5c4.png)
After:  ![after](https://user-images.githubusercontent.com/3048933/57975457-a24f3c80-79c9-11e9-8900-59c5833bc027.png)

Thanks for the library.
