### PR TITLE
offset_stroke

### DIFF
--- a/paths.scad
+++ b/paths.scad
@@ -582,7 +582,7 @@ module path_spread(path, n, spacing, sp=undef, rotate_children=true, closed=fals
 function path_cut(path, dists, closed=false, direction=false) =
       let( long_enough = len(path) >= (closed ? 3 : 2)) 
       assert(long_enough,len(path)<2 ? "Two points needed to define a path" : "Closed path must include three points")                                                       
-      !is_list(dists) ? _path_cut(path, [dists],closed, direction)[0] :
+      !is_list(dists) ? path_cut(path, [dists],closed, direction)[0] :
       let(cuts = _path_cut(path,dists,closed))
       !direction ? cuts :
               let( dir = _path_cuts_dir(path, cuts, closed),

--- a/shapes2d.scad
+++ b/shapes2d.scad
@@ -677,8 +677,8 @@ module supershape(step=0.5,m1=4,m2=undef,n1,n2=undef,n3=undef,a=1,b=undef, r=und
 //   path=turtle(["angle",360/5,"repeat",5,["move","turn"]]);
 //   stroke(path,width=.1,closed=true);
 // Example(2D): Pentagram
-//   path = turtle(["move","left",144], repeat=10);
-//   stroke(path,width=.05);
+//   path = turtle(["move","left",144], repeat=4);
+//   stroke(path,width=.05,closed=true);
 // Example(2D): Sawtooth path
 //   path = turtle([
 //       "turn", 55,


### PR DESCRIPTION
Tweaked pentagram example for turtle() path_cut had a bug when invoked
with a single distance _bezcorner would fail if $fn wasn't set and $fs
was too large added offset_stroke()