### PR TITLE
pie_slice can't accept `d` parameter

### DIFF
--- a/shapes.scad
+++ b/shapes.scad
@@ -1419,7 +1419,7 @@ module noop(spin=0, orient=UP) attachable(CENTER,spin,orient, d=0.01) {nil(); ch
 //   pie_slice(ang=60, l=20, d1=50, d2=70);
 module pie_slice(
 	ang=30, l=undef,
-	r=10, r1=undef, r2=undef,
+	r=undef, r1=undef, r2=undef,
 	d=undef, d1=undef, d2=undef,
 	h=undef, center,
 	anchor, spin=0, orient=UP


### PR DESCRIPTION
Since `r=10` is supplied as a default parameter in the module argument list, a call supplying a `d` parameter (eg. `pie_slice(d=10,h=10,ang=90);`) will error on the call to `get_radius` on line 1428 with `ERROR: Assertion 'is_undef(d)' failed: "Conflicting or redundant radius/diameter arguments given."`.
Since the calls to `get_radius` on lines 1428 and 1429 both supply `dflt=10`, line 1422 can just change to supplying `r=undef`.