### PR TITLE
Fix diff/intersect when some tags are hidden

### DIFF
--- a/attachments.scad
+++ b/attachments.scad
@@ -1235,17 +1235,20 @@ module show(tags="")
 //   }
 module diff(neg, pos=undef, keep=undef)
 {
-    difference() {
-        if (pos != undef) {
-            show(pos) children();
-        } else {
-            if (keep == undef) {
-                hide(neg) children();
+    // Don't perform the operation if the current tags are hidden
+    if (attachment_is_shown($tags)) {
+        difference() {
+            if (pos != undef) {
+                show(pos) children();
             } else {
-                hide(str(neg," ",keep)) children();
+                if (keep == undef) {
+                    hide(neg) children();
+                } else {
+                    hide(str(neg," ",keep)) children();
+                }
             }
+            show(neg) children();
         }
-        show(neg) children();
     }
     if (keep!=undef) {
         show(keep) children();
@@ -1280,17 +1283,20 @@ module diff(neg, pos=undef, keep=undef)
 //   }
 module intersect(a, b=undef, keep=undef)
 {
-    intersection() {
-        if (b != undef) {
-            show(b) children();
-        } else {
-            if (keep == undef) {
-                hide(a) children();
+    // Don't perform the operation if the current tags are hidden
+    if (attachment_is_shown($tags)) {
+        intersection() {
+            if (b != undef) {
+                show(b) children();
             } else {
-                hide(str(a," ",keep)) children();
+                if (keep == undef) {
+                    hide(a) children();
+                } else {
+                    hide(str(a," ",keep)) children();
+                }
             }
+            show(a) children();
         }
-        show(a) children();
     }
     if (keep!=undef) {
         show(keep) children();


### PR DESCRIPTION
When the first operand is hidden, some strange things happen, so this guards
against that.

Example:

    include <BOSL2/std.scad>

    part_to_show = "A"; // [A,B,C]
    part_to_hide = "B"; // [A,B,C]

    module my_part() {
        tags("A") left(10) cuboid(10);
        tags("B") diff("neg", "B") right(10) {
            cuboid(10);
            cyl(d=10, h=10, $tags="neg");
        }
        tags("C") fwd(10) cuboid(10);
    }

    show(part_to_show) hide(part_to_hide) my_part();

Tag `B` here acts very strangely when it is supposed to be hidden, and never
hides completely.