### PR TITLE
Fixes #258 - [walls] - Implement shell module

### DIFF
--- a/mutators.scad
+++ b/mutators.scad
@@ -603,5 +603,33 @@ module rainbow(list, stride=1)
     }
 }
 
+// Module: shell()
+//
+// Description:
+//   Operator that receives as input the base 3D model and outputs the same object augmented with shell walls.
+//
+// Usage:
+//   shell(w, l) base;
+//
+// Arguments:
+//   w = Width (thickness) of the shell.
+//   l = Length of the shell.
+//   base = 3D model representing object base
+//
+// Example: Square box
+//  shell(1, 20) cube([20, 20, 1]);
+module shell(width, height) {
+    union() {
+        linear_extrude(height)
+            difference() {
+                projection()
+                    children(0);
+                offset(-width)
+                    projection() children(0);
+            }
+        children(0);
+    }
+}
+
 
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap

--- a/walls.scad
+++ b/walls.scad
@@ -529,6 +529,9 @@ module corrugated_wall(h=50, l=100, thick=5, strut=5, wall=2, anchor=CENTER, spi
 //   w = Width (thickness) of the shell.
 //   l = Length of the shell.
 //   base = 3D model representing object base
+//
+// Example: Square box
+//  shell(1, 20) cube([20, 20, 1]);
 module shell(width, height) {
     union() {
         linear_extrude(height)

--- a/walls.scad
+++ b/walls.scad
@@ -517,6 +517,30 @@ module corrugated_wall(h=50, l=100, thick=5, strut=5, wall=2, anchor=CENTER, spi
     }
 }
 
+// Module: shell()
+//
+// Description:
+//   Operator that receives as input the base 3D model and outputs the same object augmented with shell walls.
+//
+// Usage:
+//   shell(w, l) base;
+//
+// Arguments:
+//   w = Width (thickness) of the shell.
+//   l = Length of the shell.
+//   base = 3D model representing object base
+module shell(width, height) {
+    union() {
+        linear_extrude(height)
+            difference() {
+                projection()
+                    children(0);
+                offset(-width)
+                    projection() children(0);
+            }
+        children(0);
+    }
+}
 
 
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap

--- a/walls.scad
+++ b/walls.scad
@@ -517,33 +517,5 @@ module corrugated_wall(h=50, l=100, thick=5, strut=5, wall=2, anchor=CENTER, spi
     }
 }
 
-// Module: shell()
-//
-// Description:
-//   Operator that receives as input the base 3D model and outputs the same object augmented with shell walls.
-//
-// Usage:
-//   shell(w, l) base;
-//
-// Arguments:
-//   w = Width (thickness) of the shell.
-//   l = Length of the shell.
-//   base = 3D model representing object base
-//
-// Example: Square box
-//  shell(1, 20) cube([20, 20, 1]);
-module shell(width, height) {
-    union() {
-        linear_extrude(height)
-            difference() {
-                projection()
-                    children(0);
-                offset(-width)
-                    projection() children(0);
-            }
-        children(0);
-    }
-}
-
 
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap


### PR DESCRIPTION
Fixes #258 

**Changes:**
  - Add `shell` module in `walls.scad`

**Context**
Operator that receives as input the base 3D model and outputs the same object augmented with shell walls.