### PR TITLE
Added ability to return default value from struct_val() if keyword is not present

### DIFF
--- a/structs.scad
+++ b/structs.scad
@@ -64,16 +64,17 @@ function struct_remove(struct, keyword) =
 
 // Function: struct_val()
 // Usage:
-//   struct_val(struct,keyword)
+//   struct_val(struct, keyword, default)
 // Description:
-//   Returns the value for the specified keyword in the structure, or undef if the keyword is not present
+//   Returns the value for the specified keyword in the structure, or default value if the keyword is not present
 // Arguments:
 //   struct = input structure
 //   keyword = keyword whose value to return
-function struct_val(struct,keyword) =
+//   default = default value to return if keyword is not present, defaults to undef
+function struct_val(struct, keyword, default=undef) =
     assert(is_def(keyword),"keyword is missing")
     let(ind = search([keyword],struct)[0])
-    ind == [] ? undef : struct[ind][1];
+    ind == [] ? default : struct[ind][1];
 
 
 // Function: struct_keys()

--- a/tests/test_structs.scad
+++ b/tests/test_structs.scad
@@ -27,6 +27,9 @@ module test_struct_val() {
     assert(struct_val(st,"Foo") == 91);
     assert(struct_val(st,"Bar") == 28);
     assert(struct_val(st,"Baz") == 9);
+    assert(struct_val(st,"Baz",5) == 9);
+    assert(struct_val(st,"Qux") == undef);
+    assert(struct_val(st,"Qux",5) == 5);
 }
 test_struct_val();
 


### PR DESCRIPTION
A simple, backward compatible change, that allows defining default value for struct keyword in `struct_val()` function.