### PR TITLE
Plut dev

### DIFF
--- a/arrays.scad
+++ b/arrays.scad
@@ -89,6 +89,18 @@ function select(list, start, end=undef) =
             :   concat([for (i = [s:1:l-1]) list[i]], [for (i = [0:1:e]) list[i]]) ;
 
 
+// Function: last()
+// Description:
+//   Returns the last element of a list, or undef if empty.
+// Usage:
+//   last(list)
+// Arguments:
+//   list = The list to get the last element of.
+// Example:
+//   l = [3,4,5,6,7,8,9];
+//   last(l);  // Returns 9.
+function last(list) = list[len(list)-1];
+
 // Function: slice()
 // Description:
 //   Returns a slice of a list.  The first item is index 0.

--- a/common.scad
+++ b/common.scad
@@ -312,38 +312,67 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
     assert(num_defined([h,l,height])<=1,"You must specify only one of `l`, `h`, and `height`")
     first_defined([h,l,height,dflt]);
 
-// Function: get_named_args(positional, named, _undef)
+// Function: get_named_args()
 // Usage:
 //   function f(pos1=_undef, pos2=_undef,...,named1=_undef, named2=_undef, ...) = let(args = get_named_args([pos1, pos2, ...], [[named1, default1], [named2, default2], ...]), named1=args[0], named2=args[1], ...)
 // Description:
 //   Given the values of some positional and named arguments,
-//   returns a list of the values assigned to named arguments,
-//   in the following way:
-//    - All named arguments which were explicitly assigned in the
-//    function call take the value provided.
-//    - All named arguments which were not provided by the user are
-//    affected from positional arguments; the priority order in which
-//    these are assigned is given by the `priority` argument, while the
-//    positional assignation is done in the order of the named arguments.
-//    - Any remaining named arguments take the provided default values.
-//  If only k positional arguments are used, then the k named values
-//  with lowest 'priority' value (among the unassigned ones) will get them.
-//  The arguments will be assigned in the order of the named values.
-//  By default these two orders coincide.
+//   returns a list of the values assigned to named parameters.
+//   in the following steps:
+//   - First, all named parameters which were explicitly assigned in the
+//      function call take their provided value.
+//   - Then, any positional arguments are assigned to remaining unassigned
+//     parameters; this is governed both by the `priority` entries
+//     (if there are `N` positional arguments, then the `N` parameters with
+//     lowest `priority` value will be assigned) and by the order of the
+//     positional arguments (matching that of the assigned named parameters).
+//     If no priority is given, then these two ordering coincide:
+//     parameters are assigned in order, starting from the first one.
+//   - Finally, any remaining named parameters can take default values.
+//     If no default values are given, then `undef` is used.
+//   .
+//   This allows an author to declare a function prototype with named or
+//   optional parameters, so that the user may then call this function
+//   using either positional or named parameters. In practice the author
+//   will declare the function as using *both* positional and named
+//   parameters, and let `get_named_args()` do the parsing from the whole
+//   set of arguments.
+//   See the example below.
+//   .
+//   This supports the user explicitly passing `undef` as a function argument.
+//   To distinguish between an intentional `undef` and
+//   the absence of an argument, we use a custom `_undef` value
+//   as a guard marking the absence of any arguments
+//   (in practice, `_undef` is a random-generated string,
+//   which will never coincide with any useful user value).
+//   This forces the author to declare all the function parameters
+//   as having `_undef` as their default value.
 // Arguments:
 //   positional = the list of values of positional arguments.
-//   named = the list of named arguments; each entry of the list has the form [passed-value, default-value, priority], where passed-value is the value that was passed at function call; default-value is the value that will be used if nothing is read from either named or positional arguments; priority is the priority assigned to this argument.
-//   _undef = the default value used by the calling function for all arguments (default is some random string that you will never use). (this is *not* undef, or any value that the user might purposely want to use as an argument value).
+//   named = the list of named arguments; each entry of the list has the form `[passed-value, <default-value>, <priority>]`, where `passed-value` is the value that was passed at function call; `default-value` is the value that will be used if nothing is read from either named or positional arguments; `priority` is the priority assigned to this argument (lower means more priority, default value is `+inf`). Since stable sorting is used, if no priority at all is given, all arguments will be read in order.
+//   _undef = the default value used by the calling function for all arguments. The default value, `_undef`, is a random string. This value **must** be the default value of all parameters in the outer function call (see example below).
 //
-//
-//
-// Examples:
-//   function f(arg1=_undef, arg2=_undef, arg3=_undef, named1=_undef, named2=_undef, named3=_undef) = let(named = get_named_args([arg1, arg2, arg3], [[named1, "default1"], [named2, "default2"], [named3, "default3"]])) named;
-//   echo(f()); // ["default1", "default2", "default3"]
-//   echo(f("given2", "given3", named1="given1")); // ["given1", "given2", "given3"]
-//   echo(f("given1")); // ["given1", "default2", "default3"]
-//   echo(f(named1="given1", "given2")); // ["given1", "given2", "default3"]
-//   echo(f(undef, named1="given1", undef)); // ["given1", undef, undef]
+// Example: a function with prototype `f(named1,< <named2>, named3 >)`
+//   function f(_p1=_undef, _p2=_undef, _p3=_undef,
+//              arg1=_undef, arg2=_undef, arg3=_undef) =
+//      let(named = get_named_args([_p1, _p2, _p3],
+//          [[arg1, "default1",0], [arg2, "default2",2], [arg3, "default3",1]]))
+//      named;
+//   // all default values or all parameters provided:
+//   echo(f());
+//   // ["default1", "default2", "default3"]
+//   echo(f("given2", "given3", arg1="given1"));
+//   // ["given1", "given2", "given3"]
+//   
+//   // arg1 has highest priority, and arg3 is higher than arg2:
+//   echo(f("given1"));
+//   // ["given1", "default2", "default3"]
+//   echo(f("given3", arg1="given1"));
+//   // ["given1", "default2", "given3"]
+//   
+//   // explicitly passing undef is allowed:
+//   echo(f(undef, arg1="given1", undef));
+//   // ["given1", undef, undef]
 
 // a value that the user should never enter randomly;
 // result of `dd if=/dev/random bs=32 count=1 |base64` :
@@ -366,7 +395,8 @@ function get_named_args(positional, named,_undef=_undef) =
         // those elements which have no priority assigned go last (prio=+∞):
         prio = sortidx([for(u=unknown) default(named[u][2], 1/0)]),
         // list of indices of values assigned from positional arguments:
-        assigned = sort([for(i=[0:1:n_positional-1]) prio[i]]))
+        assigned = [for(a=sort([for(i=[0:1:n_positional-1]) prio[i]]))
+          unknown[a]])
     [ for(e = enumerate(named))
       let(idx=e[0], val=e[1][0], ass=search(idx, assigned))
         val != _undef ? val :

--- a/common.scad
+++ b/common.scad
@@ -314,12 +314,7 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
 
 // Function: get_named_args(positional, named, _undef)
 // Usage:
-//   function f(pos1=_undef, pos2=_undef,...,
-//              named1=_undef, named2=_undef, ...) =
-//    let(args = get_named_args([pos1, pos2, ...],
-//                              [[named1, default1], [named2, default2], ...]),
-//        named1=args[0], named2=args[1], ...)
-//        ...
+//   function f(pos1=_undef, pos2=_undef,...,named1=_undef, named2=_undef, ...) = let(args = get_named_args([pos1, pos2, ...], [[named1, default1], [named2, default2], ...]), named1=args[0], named2=args[1], ...)
 // Description:
 //   Given the values of some positional and named arguments,
 //   returns a list of the values assigned to named arguments,
@@ -331,20 +326,15 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
 //    these are assigned is given by the `priority` argument, while the
 //    positional assignation is done in the order of the named arguments.
 //    - Any remaining named arguments take the provided default values.
-// Arguments:
-//   positional = the list of values of positional arguments.
-//   named = the list of named arguments; each entry of the list has the
-//   form [passed-value, default-value, priority], where
-//      passed-value is the value that was passed at function call;
-//      default-value is the value that will be used if nothing is read
-//      from either named or positional arguments;
-//      priority is the priority assigned to this argument.
-//   _undef = the default value used by the calling function for all arguments (default is some random string that you will never use). (this is *not* undef, or any value that the user might purposely want to use as an argument value).
-//
 //  If only k positional arguments are used, then the k named values
 //  with lowest 'priority' value (among the unassigned ones) will get them.
 //  The arguments will be assigned in the order of the named values.
 //  By default these two orders coincide.
+// Arguments:
+//   positional = the list of values of positional arguments.
+//   named = the list of named arguments; each entry of the list has the form [passed-value, default-value, priority], where passed-value is the value that was passed at function call; default-value is the value that will be used if nothing is read from either named or positional arguments; priority is the priority assigned to this argument.
+//   _undef = the default value used by the calling function for all arguments (default is some random string that you will never use). (this is *not* undef, or any value that the user might purposely want to use as an argument value).
+//
 //
 //
 // Examples:

--- a/common.scad
+++ b/common.scad
@@ -348,16 +348,12 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
 //
 //
 // Examples:
-// function f(arg1=_undef, arg2=_undef, arg3=_undef,
-//   named1=_undef, named2=_undef, named3=_undef) =
-//   let(named = get_named_args([arg1, arg2, arg3],
-//     [[named1, "default1"], [named2, "default2"], [named3, "default3"]]))
-//   named;
-// echo(f()); // ["default1", "default2", "default3"]
-// echo(f("given2", "given3", named1="given1")); // ["given1", "given2", "given3"]
-// echo(f("given1")); // ["given1", "default2", "default3"]
-// echo(f(named1="given1", "given2")); // ["given1", "given2", "default3"]
-// echo(f(undef, named1="given1", undef)); // ["given1", undef, undef]
+//   function f(arg1=_undef, arg2=_undef, arg3=_undef, named1=_undef, named2=_undef, named3=_undef) = let(named = get_named_args([arg1, arg2, arg3], [[named1, "default1"], [named2, "default2"], [named3, "default3"]])) named;
+//   echo(f()); // ["default1", "default2", "default3"]
+//   echo(f("given2", "given3", named1="given1")); // ["given1", "given2", "given3"]
+//   echo(f("given1")); // ["given1", "default2", "default3"]
+//   echo(f(named1="given1", "given2")); // ["given1", "given2", "default3"]
+//   echo(f(undef, named1="given1", undef)); // ["given1", undef, undef]
 
 // a value that the user should never enter randomly;
 // result of `dd if=/dev/random bs=32 count=1 |base64` :

--- a/common.scad
+++ b/common.scad
@@ -312,7 +312,53 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
     assert(num_defined([h,l,height])<=1,"You must specify only one of `l`, `h`, and `height`")
     first_defined([h,l,height,dflt]);
 
+// Function: get_named_args(anonymous, named, _undef)
+// Usage:
+// function f(anon1=_undef, anon2=_undef,...,
+//     named1=_undef, named2=_undef, ...) =
+//     let(args = get_named_args([anon1, anon2, ...],
+//        [[named1, default1], [named2, default2], ...]))
+//        ...
+// Description:
+//   given a set of anonymous and named arguments, returns the values of
+//   named arguments, in order.
+//    - All named arguments which were provided by the user take the
+//    value provided.
+//    - All named arguments which were not provided by the user are
+//    affected from anonymous arguments, in order.
+//    - Any remaining named arguments take the provided default values.
+// Arguments:
+//   anonymous = the list of values of anonymous arguments.
+//   named = the list of [passed-value, default value] of named arguments.
+//   _undef = the default value used by the calling function for all
+//   arguments (this is *not* undef, or any value that the user might
+//   purposely want to use as an argument value).
+// Examples:
+// function f(arg1=_undef, arg2=_undef, arg3=_undef,
+//   named1=_undef, named2=_undef, named3=_undef) =
+//   let(named = get_named_args([arg1, arg2, arg3],
+//     [[named1, "default1"], [named2, "default2"], [named3, "default3"]]))
+//   named;
+// echo(f()); // ["default1", "default2", "default3"]
+// echo(f("given2", "given3", named1="given1")); // ["given1", "given2", "given3"]
+// echo(f("given1")); // ["given1", "default2", "default3"]
+// echo(f(named1="given1", "given2")); // ["given1", "given2", "default3"]
+// echo(f(undef, named1="given1", undef)); // ["given1", undef, undef]
 
+// a value that the user should never enter randomly;
+// result of `dd if=/dev/random bs=32 count=1 |base64` :
+_undef="LRG+HX7dy89RyHvDlAKvb9Y04OTuaikpx205CTh8BSI";
+
+function get_named_args(anonymous, named,_undef=_undef) =
+    /* u: set of undefined indices in named arguments */
+    let(from_anon = [for(p=enumerate(named)) if(p[1][0]==_undef) p[0]],
+        n = len(anonymous))
+    echo("from_anon:", from_anon)
+    [ for(e = enumerate(named))
+        // if the value is defined, return it:
+        e[1][0] != _undef ? e[1][0] :
+        let(k = anonymous[search(e[0], from_anon)[0]])
+        k != _undef ? k : e[1][1] ];
 // Function: scalar_vec3()
 // Usage:
 //   scalar_vec3(v, <dflt>);

--- a/common.scad
+++ b/common.scad
@@ -314,10 +314,10 @@ function get_height(h=undef,l=undef,height=undef,dflt=undef) =
 
 // Function: get_named_args(positional, named, _undef)
 // Usage:
-// function f(pos1=_undef, pos2=_undef,...,
-//     named1=_undef, named2=_undef, ...) =
-//     let(args = get_named_args([pos1, pos2, ...],
-//        [[named1, default1], [named2, default2], ...]),
+//   function f(pos1=_undef, pos2=_undef,...,
+//              named1=_undef, named2=_undef, ...) =
+//    let(args = get_named_args([pos1, pos2, ...],
+//                              [[named1, default1], [named2, default2], ...]),
 //        named1=args[0], named2=args[1], ...)
 //        ...
 // Description:

--- a/mutators.scad
+++ b/mutators.scad
@@ -67,17 +67,17 @@ module bounding_box(excess=0) {
 // Function&Module: half_of()
 //
 // Usage: as module
-//   half_of(v, [cp], [s]) ...
+//   half_of(v, <cp>, <s>) ...
 // Usage: as function
-//   half_of(v, [cp], p, [s])...
+//   half_of(v, <cp>, p, <s>)...
 //
 // Description:
 //   Slices an object at a cut plane, and masks away everything that is on one side.
 //   * Called as a function with a path in the `p` argument, returns the
-//   intersection of path `p` and given half-space.
+//       intersection of path `p` and given half-space.
 //   * Called as a function with a 2D path in the `p` argument
-//   and a 2D vector `p`, returns the intersection of path `p` and given
-//   half-plane.
+//       and a 2D vector `p`, returns the intersection of path `p` and given
+//       half-plane.
 //
 // Arguments:
 //   v = Normal of plane to slice at.  Keeps everything on the side the normal points to.  Default: [0,0,1] (UP)
@@ -121,7 +121,7 @@ module half_of(v=UP, cp, s=1000, planar=false)
 function half_of(_arg1=_undef, _arg2=_undef, _arg3=_undef, _arg4=_undef,
     v=_undef, cp=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3, _arg4],
-        [[v,undef,0], [cp,0,2], [p,undef,1], [s,1e4,3]]),
+        [[v,undef,0], [cp,0,2], [p,undef,1], [s, 1e4]]),
         v=args[0], cp0=args[1], p=args[2], s=args[3],
         cp = is_num(cp0) ? cp0*unit(v) : cp0)
     assert(is_vector(v,2)||is_vector(v,3),
@@ -160,12 +160,12 @@ function half_of(_arg1=_undef, _arg2=_undef, _arg3=_undef, _arg4=_undef,
 // Function&Module: left_half()
 //
 // Usage: as module
-//   left_half([s], [x]) ...
-//   left_half(planar=true, [s], [x]) ...
+//   left_half(<s>, <x>) ...
+//   left_half(planar=true, <s>, <x>) ...
 // Usage: as function
-//   left_half([s], [x], path)
-//   left_half([s], [x], region)
-//   left_half([s], [x], vnf)
+//   left_half(<s>, <x>, path)
+//   left_half(<s>, <x>, region)
+//   left_half(<s>, <x>, vnf)
 //
 // Description:
 //   Slices an object at a vertical Y-Z cut plane, and masks away everything that is right of it.
@@ -197,7 +197,7 @@ module left_half(s=1000, x=0, planar=false)
 function left_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[1,0,0], cp=x, p=p);
 
@@ -208,6 +208,7 @@ function left_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
 // Usage:
 //   right_half([s], [x]) ...
 //   right_half(planar=true, [s], [x]) ...
+//
 //
 // Description:
 //   Slices an object at a vertical Y-Z cut plane, and masks away everything that is left of it.
@@ -239,7 +240,7 @@ module right_half(s=1000, x=0, planar=false)
 function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[-1,0,0], cp=x, p=p);
 
@@ -281,7 +282,7 @@ module front_half(s=1000, y=0, planar=false)
 function front_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[0,1,0], cp=x, p=p);
 
@@ -323,7 +324,7 @@ module back_half(s=1000, y=0, planar=false)
 function back_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[0,-1,0], cp=x, p=p);
 
@@ -357,7 +358,7 @@ module bottom_half(s=1000, z=0)
 function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[0,0,-1], cp=x, p=p);
 
@@ -391,7 +392,7 @@ module top_half(s=1000, z=0)
 function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
     x=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3],
-    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+    [[x, 0,1], [p,undef,0], [s, 1e4]]),
         x=args[0], p=args[1], s=args[2])
     half_of(v=[0,0,1], cp=x, p=p);
 

--- a/mutators.scad
+++ b/mutators.scad
@@ -118,7 +118,7 @@ module half_of(v=UP, cp, s=1000, planar=false)
     }
 }
 
-function half_of(v, arg1, arg2, cp, p, s=1e4) =
+function half_of(v, arg1, arg2, s=1e4, cp, p) =
     /* may be called as either:
      *                   p=   cp=
      * 1. (v, p)         arg1 0
@@ -158,14 +158,15 @@ function half_of(v, arg1, arg2, cp, p, s=1e4) =
             // create self-intersection or whiskers:
             z[i]*z[j] >= 0 ? [] : [(z[j]*p[i]-z[i]*p[j])/(z[j]-z[i])]) ]
         :
-    assert(is_region(p), str("must provide point, path or region"))
-    assert(len(v) == 2, str("3D vector not compatible with region"))
-    let(u=unit(v), w=[-u[1], u[0]],
-        R=[[cp+s*w, cp+s*(v+v), cp+s*(v-w), cp-s*w]]) // bounding region
-    intersection(R, p);
-    // FIXME: find something intelligent to do if p is a VNF
-    // FIXME: scadlib csg.scad, csg_hspace()
-
+    is_region(p) ?
+        assert(len(v) == 2, str("3D vector not compatible with region"))
+        let(u=unit(v), w=[-u[1], u[0]],
+            R=[[cp+s*w, cp+s*(v+v), cp+s*(v-w), cp-s*w]]) // half-plane
+        intersection(R, p)
+        :
+    is_vnf(p) ?
+    vnf_halfspace(halfspace=concat(v,[-v*cp]), vnf=p) :
+    assert(false, "must pass either a point, a path, a region, or a VNF");
 
 // Module: left_half()
 //

--- a/mutators.scad
+++ b/mutators.scad
@@ -121,16 +121,9 @@ module half_of(v=UP, cp, s=1000, planar=false)
 function half_of(_arg1=_undef, _arg2=_undef, _arg3=_undef, _arg4=_undef,
     v=_undef, cp=_undef, p=_undef, s=_undef) =
     let(args=get_named_args([_arg1, _arg2, _arg3, _arg4],
-        [[v], [cp, 0], [p], [s, 1e4]]),
+        [[v,undef,0], [cp,0,2], [p,undef,1], [s,1e4,3]]),
         v=args[0], cp0=args[1], p=args[2], s=args[3],
         cp = is_num(cp0) ? cp0*unit(v) : cp0)
-    echo("_undef=", _undef)
-    echo("v=", v)
-    echo("cp=", cp)
-    echo("p=", p)
-    echo("vnf?", is_vnf(p))
-    echo("region?", is_region(p))
-    echo("s=", s)
     assert(is_vector(v,2)||is_vector(v,3),
       "must provide a half-plane or half-space")
     let(d=len(v))
@@ -164,11 +157,15 @@ function half_of(_arg1=_undef, _arg2=_undef, _arg3=_undef, _arg4=_undef,
         :
     assert(false, "must pass either a point, a path, a region, or a VNF");
 
-// Module: left_half()
+// Function&Module: left_half()
 //
-// Usage:
+// Usage: as module
 //   left_half([s], [x]) ...
 //   left_half(planar=true, [s], [x]) ...
+// Usage: as function
+//   left_half([s], [x], path)
+//   left_half([s], [x], region)
+//   left_half([s], [x], vnf)
 //
 // Description:
 //   Slices an object at a vertical Y-Z cut plane, and masks away everything that is right of it.
@@ -197,10 +194,16 @@ module left_half(s=1000, x=0, planar=false)
         }
     }
 }
+function left_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[1,0,0], cp=x, p=p);
 
 
 
-// Module: right_half()
+// Function&Module: right_half()
 //
 // Usage:
 //   right_half([s], [x]) ...
@@ -233,10 +236,16 @@ module right_half(s=1000, x=0, planar=false)
         }
     }
 }
+function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[-1,0,0], cp=x, p=p);
 
 
 
-// Module: front_half()
+// Function&Module: front_half()
 //
 // Usage:
 //   front_half([s], [y]) ...
@@ -269,10 +278,16 @@ module front_half(s=1000, y=0, planar=false)
         }
     }
 }
+function front_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[0,1,0], cp=x, p=p);
 
 
 
-// Module: back_half()
+// Function&Module: back_half()
 //
 // Usage:
 //   back_half([s], [y]) ...
@@ -305,10 +320,16 @@ module back_half(s=1000, y=0, planar=false)
         }
     }
 }
+function back_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[0,-1,0], cp=x, p=p);
 
 
 
-// Module: bottom_half()
+// Function&Module: bottom_half()
 //
 // Usage:
 //   bottom_half([s], [z]) ...
@@ -333,10 +354,16 @@ module bottom_half(s=1000, z=0)
         }
     }
 }
+function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[0,0,-1], cp=x, p=p);
 
 
 
-// Module: top_half()
+// Function&Module: top_half()
 //
 // Usage:
 //   top_half([s], [z]) ...
@@ -361,6 +388,12 @@ module top_half(s=1000, z=0)
         }
     }
 }
+function right_half(_arg1=_undef, _arg2=_undef, _arg3=_undef,
+    x=_undef, p=_undef, s=_undef) =
+    let(args=get_named_args([_arg1, _arg2, _arg3],
+    [[x, 0,1], [p,undef,0], [s, 1e4,2]]),
+        x=args[0], p=args[1], s=args[2])
+    half_of(v=[0,0,1], cp=x, p=p);
 
 
 

--- a/regions.scad
+++ b/regions.scad
@@ -20,8 +20,7 @@
 //   is_region(x);
 // Description:
 //   Returns true if the given item looks like a region.  A region is defined as a list of zero or more paths.
-function is_region(x) =
-  is_list(x) && all([for(y=x) is_path(y, len(x[0][0]))]);
+function is_region(x) = is_list(x) && is_path(x.x);
 
 
 // Function: close_region()

--- a/regions.scad
+++ b/regions.scad
@@ -20,7 +20,8 @@
 //   is_region(x);
 // Description:
 //   Returns true if the given item looks like a region.  A region is defined as a list of zero or more paths.
-function is_region(x) = is_list(x) && is_path(x.x);
+function is_region(x) =
+  is_list(x) && all([for(y=x) is_path(y, len(x[0][0]))]);
 
 
 // Function: close_region()

--- a/vnf.scad
+++ b/vnf.scad
@@ -829,14 +829,14 @@ module vnf_validate(vnf, size=1, show_warns=true, check_isects=false) {
 
 // Section: VNF transformations
 //
+
 // Function: vnf_halfspace(halfspace, vnf)
 // Usage:
 //   vnf_halfspace([a,b,c,d], vnf)
 // Description:
 //   returns the intersection of the VNF with the given half-space.
 // Arguments:
-//   halfspace = half-space to intersect with, given as the four
-//   coefficients of the affine inequation a*x+b*y+c*z+d ≥ 0.
+//   halfspace = half-space to intersect with, given as the four coefficients of the affine inequation a\*x+b\*y+c\*z≥ d.
 
 function _vnf_halfspace_pts(halfspace, points, faces,
   inside=undef, coords=[], map=[]) =
@@ -861,7 +861,7 @@ function _vnf_halfspace_pts(halfspace, points, faces,
     // termination test:
     i >= len(points) ? [ coords, map, inside ] :
     let(inside = !is_undef(inside) ? inside :
-        [for(x=points) halfspace*concat(x,[1]) >= 0],
+        [for(x=points) halfspace*concat(x,[-1]) >= 0],
         pi = points[i])
     // inside half-space: keep the point (and reindex)
     inside[i] ? _vnf_halfspace_pts(halfspace, points, faces, inside,
@@ -871,10 +871,10 @@ function _vnf_halfspace_pts(halfspace, points, faces,
       each if(j!=undef) [f[(j+1)%m], f[(j+m-1)%m]] ]),
     // filter those which lie in half-space:
         adj2 = [for(x=adj) if(inside[x]) x],
-        zi = halfspace*concat(pi, [1]))
+        zi = halfspace*concat(pi, [-1]))
     _vnf_halfspace_pts(halfspace, points, faces, inside,
         // new points: we append all these intersection points
-        concat(coords, [for(j=adj2) let(zj=halfspace*concat(points[j],[1]))
+        concat(coords, [for(j=adj2) let(zj=halfspace*concat(points[j],[-1]))
             (zi*points[j]-zj*pi)/(zi-zj)]),
         // map: we add the info
         concat(map, [[for(y=enumerate(adj2)) [y[1], n+y[0]]]]));
@@ -950,7 +950,4 @@ function vnf_halfspace(_arg1=_undef, _arg2=_undef,
         loops=[for(p=paths) if(p[0] == last(p)) p])
     [coords, concat(newfaces, loops)];
 
-//
-//
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap
-//

--- a/vnf.scad
+++ b/vnf.scad
@@ -827,5 +827,130 @@ module vnf_validate(vnf, size=1, show_warns=true, check_isects=false) {
     color([0.5,0.5,0.5,0.5]) vnf_polyhedron(vnf);
 }
 
+// Section: VNF transformations
+//
+// Function: vnf_halfspace(halfspace, vnf)
+// Usage:
+//   vnf_halfspace([a,b,c,d], vnf)
+// Description:
+//   returns the intersection of the VNF with the given half-space.
+// Arguments:
+//   halfspace = half-space to intersect with, given as the four
+//   coefficients of the affine inequation a*x+b*y+c*z+d ≥ 0.
 
+function _vnf_halfspace_pts(halfspace, points, faces,
+  inside=undef, coords=[], map=[]) =
+/* Recursive function to compute the intersection of points (and edges,
+ * but not faces) with with the half-space.
+ * Parameters:
+ * halfspace  a vector(4)
+ * points     a list of points3d
+ * faces      a list of indexes in points
+ * inside     a vector{bool} determining which points belong to the
+ *            half-space; if undef, it is initialized at first loop.
+ * coords     the coordinates of the points in the intersection
+ * map        the logical map (old point) → (new point(s)):
+ *   if point i is kept, then map[i] = new-index-for-i;
+ *   if point i is dropped, then map[i] = [[j1, k1], [j2, k2], …],
+ *      where points j1,… are kept (old index)
+ *      and k1,… are the matching intersections (new index).
+ * Returns the triple [coords, map, inside].
+ *
+ */
+    let(i=len(map), n=len(coords)) // we are currently processing point i
+    // termination test:
+    i >= len(points) ? [ coords, map, inside ] :
+    let(inside = !is_undef(inside) ? inside :
+        [for(x=points) halfspace*concat(x,[1]) >= 0],
+        pi = points[i])
+    // inside half-space: keep the point (and reindex)
+    inside[i] ? _vnf_halfspace_pts(halfspace, points, faces, inside,
+        concat(coords, [pi]), concat(map, [n]))
+    : // else: compute adjacent vertices (adj)
+    let(adj = unique([for(f=faces) let(m=len(f), j=search(i, f)[0])
+      each if(j!=undef) [f[(j+1)%m], f[(j+m-1)%m]] ]),
+    // filter those which lie in half-space:
+        adj2 = [for(x=adj) if(inside[x]) x],
+        zi = halfspace*concat(pi, [1]))
+    _vnf_halfspace_pts(halfspace, points, faces, inside,
+        // new points: we append all these intersection points
+        concat(coords, [for(j=adj2) let(zj=halfspace*concat(points[j],[1]))
+            (zi*points[j]-zj*pi)/(zi-zj)]),
+        // map: we add the info
+        concat(map, [[for(y=enumerate(adj2)) [y[1], n+y[0]]]]));
+function _vnf_halfspace_face(face, map, inside, i=0,
+    newface=[], newedge=[], exit) =
+/* Recursive function to intersect a face of the VNF with the half-plane.
+ * Arguments:
+ *   face: the list of points of the face (old indices).
+ *   map: as produced by _vnf_halfspace_pts
+ *   inside: vector{bool} containing half-space info
+ *   i: index for iteration
+ *   exit: boolean; is first point in newedge an exit or an entrance from
+ *     half-space?
+ *   newface: list of (new indexes of) points on the face
+ *   newedge: list of new points on the plane (even number of points)
+ *  Return value: [newface, new-edges], where new-edges is a list of
+ *  pairs [entrance-node, exit-node] (new indices).
+ */
+// termination condition:
+    (i >= len(face)) ? [ newface,
+    // if exit==true then we return newedge[1,0], newedge[3,2], ...
+    // otherwise newedge[0,1], newedge[2,3], ...;
+    // all edges are oriented (entrance->exit), so that by following the
+    // arrows we obtain a correctly-oriented face:
+    let(k = exit ? 0 : 1)
+    [for(i=[0:2:len(newedge)-2]) [newedge[i+k], newedge[i+1-k]]] ]
+    : // recursion case: p is current point on face, q is next point
+    let(p = face[i], q = face[(i+1)%len(face)],
+        // if p is inside half-plane, keep it in the new face:
+        newface0 = inside[p] ?  concat(newface, [map[p]]) : newface)
+        // if the current segment does not intersect, this is all:
+        inside[p] == inside[q] ? _vnf_halfspace_face(face, map, inside, i+1,
+            newface0, newedge, exit)
+        : // otherwise, we must add the intersection point:
+        // rename the two points p,q as inner and outer point:
+        let(in = inside[p] ? p : q, out = p+q-in,
+            inter=[for(a=map[out]) if(a[0]==in) a[1]][0])
+        _vnf_halfspace_face(face, map, inside, i+1,
+            concat(newface0, [inter]),
+            concat(newedge, [inter]),
+            is_undef(exit) ? inside[p] : exit);
+function _vnf_halfspace_paths(edges, i=0, paths=[]) =
+/* given a set of oriented edges [x,y],
+   returns all paths [x,y,z,..] that may be formed from these edges.
+   A closed path will be returned with equal first and last point.
+   i: index of currently examined edge
+ */
+   i >= len(edges) ? paths : // termination condition
+   let(e = edges[i],
+       s = [for(x=enumerate(paths)) if(x[1][len(x[1])-1] == e[0]) x[0]])
+   _vnf_halfspace_paths(edges, i+1,
+   // if cannot attach to previous path: create a new one
+       s == [] ? concat(paths, [e]) :
+   // otherwise, attach to found path
+       [for(x=enumerate(paths)) x[0]==s[0] ? concat(x[1], [e[1]]) : x[1]]);
+function vnf_halfspace(_arg1=_undef, _arg2=_undef,
+    halfspace=_undef, vnf=_undef) =
+    // here is where we wish that OpenSCAD had array lvalues...
+    let(args=get_named_args([_arg1, _arg2], [[halfspace],[vnf]]),
+        halfspace=args[0], vnf=args[1])
+    assert(is_vector(halfspace, 4),
+        "half-space must be passed as a length 4 affine form")
+    assert(is_vnf(vnf), "must pass a vnf")
+        // read points
+    let(tmp1=_vnf_halfspace_pts(halfspace, vnf[0], vnf[1]),
+        coords=tmp1[0], map=tmp1[1], inside=tmp1[2],
+        // cut faces and generate edges
+        tmp2= [for(f=vnf[1]) _vnf_halfspace_face(f, map, inside)],
+        newfaces=[for(x=tmp2) if(x[0]!=[]) x[0]],
+        newedges=[for(x=tmp2) each x[1]],
+        // generate new faces
+        paths=_vnf_halfspace_paths(newedges),
+        loops=[for(p=paths) if(p[0] == p[len(p)-1]) p])
+    [coords, concat(newfaces, loops)];
+
+//
+//
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap
+//

--- a/vnf.scad
+++ b/vnf.scad
@@ -924,7 +924,7 @@ function _vnf_halfspace_paths(edges, i=0, paths=[]) =
  */
    i >= len(edges) ? paths : // termination condition
    let(e = edges[i],
-       s = [for(x=enumerate(paths)) if(x[1][len(x[1])-1] == e[0]) x[0]])
+       s = [for(x=enumerate(paths)) if(last(x[1]) == e[0]) x[0]])
    _vnf_halfspace_paths(edges, i+1,
    // if cannot attach to previous path: create a new one
        s == [] ? concat(paths, [e]) :
@@ -947,7 +947,7 @@ function vnf_halfspace(_arg1=_undef, _arg2=_undef,
         newedges=[for(x=tmp2) each x[1]],
         // generate new faces
         paths=_vnf_halfspace_paths(newedges),
-        loops=[for(p=paths) if(p[0] == p[len(p)-1]) p])
+        loops=[for(p=paths) if(p[0] == last(p)) p])
     [coords, concat(newfaces, loops)];
 
 //


### PR DESCRIPTION
This extends the `half_of()` (etc.) modules to also work as functions (when applied to paths/regions/VNFs). It contains an implementation of intersection of a VNF with a half-space.

This also contains a `get_named_args()` function that might be useful for defining functions that may be called with named and/or positional arguments.