### PR TITLE
Check openscad return code in run_tests.sh

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -18,8 +18,9 @@ for testscript in $INFILES ; do
     testfile="tests/test_$repname"
     if [ -f "$testfile" ] ; then
         ${OPENSCAD} -o out.echo --hardwarnings --check-parameters true --check-parameter-ranges true $testfile 2>&1
+        retcode=$?
         res=$(cat out.echo)
-        if [ "$res" = "" ] ; then
+        if [ $retcode -eq 0 ] && [ "$res" = "" ] ; then
             echo "$repname: PASS"
         else
             echo "$repname: FAIL!"


### PR DESCRIPTION
I found that even though my openscad was crashing on tests_hull.scad, this script reported that it had passed.  This change saves the exit code of the openscad command, and checks that it is 0 (success).