### PR TITLE
Fix `cyl` ignoring `circum` when a `chamfer` or `rounding` is provided

### DIFF
--- a/shapes.scad
+++ b/shapes.scad
@@ -793,17 +793,19 @@ module cyl(
     circum=false, realign=false, from_end=false,
     center, anchor, spin=0, orient=UP
 ) {
-    r1 = get_radius(r1=r1, r=r, d1=d1, d=d, dflt=1);
-    r2 = get_radius(r1=r2, r=r, d1=d2, d=d, dflt=1);
     l = first_defined([l, h, 1]);
-    sides = segs(max(r1,r2));
+    _r1 = get_radius(r1=r1, r=r, d1=d1, d=d, dflt=1);
+    _r2 = get_radius(r1=r2, r=r, d1=d2, d=d, dflt=1);
+    sides = segs(max(_r1,_r2));
     sc = circum? 1/cos(180/sides) : 1;
+    r1=_r1*sc;
+    r2=_r2*sc;
     phi = atan2(l, r2-r1);
     anchor = get_anchor(anchor,center,BOT,CENTER);
     attachable(anchor,spin,orient, r1=r1, r2=r2, l=l) {
         zrot(realign? 180/sides : 0) {
             if (!any_defined([chamfer, chamfer1, chamfer2, rounding, rounding1, rounding2])) {
-                cylinder(h=l, r1=r1*sc, r2=r2*sc, center=true, $fn=sides);
+                cylinder(h=l, r1=r1, r2=r2, center=true, $fn=sides);
             } else {
                 vang = atan2(l, r1-r2)/2;
                 chang1 = 90-first_defined([chamfang1, chamfang, vang]);

--- a/tests/test_shapes.scad
+++ b/tests/test_shapes.scad
@@ -39,5 +39,37 @@ module test_spheroid() {
 test_spheroid();
 
 
+module test_cyl() {
+    $fn=12;
+    shape_compare() {
+        cyl(r=50,l=10,circum=true,anchor=BOTTOM);
+        cylinder(r=50/cos(180/12),l=10);
+    }
+    shape_compare() {
+        cyl(r=50,l=10,circum=false,anchor=BOTTOM);
+        cylinder(r=50,l=10);
+    }
+    shape_compare() {
+        cyl(r=50,l=10,chamfer=1,circum=true,anchor=BOTTOM);
+        union() {
+            r=50/cos(180/12);
+            cylinder(r1=r-1,r2=r,l=1);
+            up(1) cylinder(r=r,l=8);
+            up(9) cylinder(r1=r,r2=r-1,l=1);
+        }
+    }
+    shape_compare() {
+        cyl(r=50,l=10,chamfer=1,circum=false,anchor=BOTTOM);
+        union() {
+            r=50;
+            cylinder(r1=r-1,r2=r,l=1);
+            up(1) cylinder(r=r,l=8);
+            up(9) cylinder(r1=r,r2=r-1,l=1);
+        }
+    }
+}
+test_cyl();
+
+
 
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap


### PR DESCRIPTION
Demonstrates (with a test) and fixes `cyl` silently ignoring `circum=true` when any chamfer or rounding argument is provided.

I'd love to have a way to make a test that actually fails, instead of just rendering the problem, but the `shape_compare()` tests I've provided at least demonstrate the problem. If there's a better way, I'm happy to use it instead, if someone can point me in the right direction.