### PR TITLE
Refactor and tidy BOSL's shell scripts

### DIFF
--- a/scripts/increment_version.sh
+++ b/scripts/increment_version.sh
@@ -1,15 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 VERFILE="version.scad"
 
-vernums=$(grep ^BOSL_VERSION "$VERFILE" | sed 's/^.*[[]\([0-9,]*\)[]].*$/\1/')
-major=$(echo "$vernums" | awk -F, '{print $1}')
-minor=$(echo "$vernums" | awk -F, '{print $2}')
-revision=$(echo "$vernums" | awk -F, '{print $3}')
+if [[ "$(cat "$VERFILE")" =~  BOSL_VERSION.*=.*\[([0-9]+),\ *([0-9]+),\ *([0-9]+)\]\; ]]; then
+  major=${BASH_REMATCH[1]} minor=${BASH_REMATCH[2]} revision=${BASH_REMATCH[3]}
+  new_revision=$(( revision+1 ))
 
-newrev=$(($revision+1))
-echo "Current Version: $major.$minor.$revision"
-echo "New Version: $major.$minor.$newrev"
+  echo "Current Version: $major.$minor.$revision"
+  echo "New Version: $major.$minor.$new_revision"
 
-sed -i '' 's/^BOSL_VERSION = .*$/BOSL_VERSION = ['"$major,$minor,$newrev];/g" $VERFILE
-
+  sed -i 's/^BOSL_VERSION = .*$/BOSL_VERSION = ['"$major,$minor,$new_revision];/g" "$VERFILE"
+else
+  echo "Could not extract version number from $VERFILE" >&2
+  exit 1
+fi

--- a/scripts/linecount.sh
+++ b/scripts/linecount.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-lib_comment_lines=$(grep '^// ' *.scad | wc -l)
-lib_code_lines=$(grep '^ *[^ /]' *.scad | wc -l)
-script_code_lines=$(grep '^ *[^ /]' scripts/*.sh scripts/*.py | wc -l)
-example_code_lines=$(grep '^ *[^ /]' examples/*.scad | wc -l)
-test_code_lines=$(grep '^ *[^ /]' tests/*.scad | wc -l)
-tutorial_lines=$(grep '^ *[^ /]' tutorials/*.md | wc -l)
+lib_comment_lines=$(cat -- *.scad | grep -c '^// ')
+tutorial_lines=$(cat tutorials/*.md | grep -c '^ *[^ /]')
 
-y=$(printf "%06d" 13)
-
-printf "Documentation Lines : %6d\n" $(($lib_comment_lines+$tutorial_lines))
-printf "Example Code Lines  : %6d\n" $example_code_lines
-printf "Library Code Lines  : %6d\n" $lib_code_lines
-printf "Support Script Lines: %6d\n" $script_code_lines
-printf "Test Code Lines     : %6d\n" $test_code_lines
+printf '%-20s: %6d\n' \
+  'Documentation Lines'  "$(( lib_comment_lines + tutorial_lines ))" \
+  'Example Code Lines'   "$(cat examples/*.scad | grep -c '^ *[^ /]')" \
+  'Library Code Lines'   "$(cat -- *.scad | grep -c '^ *[^ /]')" \
+  'Support Script Lines' "$(cat scripts/*.sh scripts/*.py | grep -c '^ *[^ /]')" \
+  'Test Code Lines'      "$(cat tests/*.scad | grep -c '^ *[^ /]')"
 

--- a/scripts/make_tutorials.sh
+++ b/scripts/make_tutorials.sh
@@ -1,40 +1,38 @@
 #!/bin/bash
 
-FORCED=""
-FILES=""
-DISPMD=""
+DISPMD=0
+GEN_ARGS=()
+FILES=()
 for opt in "$@" ; do
-  case $opt in
-    -f ) FORCED=$opt ;;
-    -d ) DISPMD=$opt ;;
-    -* ) echo "Unknown option $opt"; exit -1 ;;
-    * ) FILES="$FILES $opt" ;;
+  case "$opt" in
+    -f ) GEN_ARGS+=(-f) ;;
+    -d ) DISPMD=1 ;;
+    -* ) echo "Unknown option $opt" >&2; exit 1 ;;
+    * ) FILES+=("$opt") ;;
   esac
 done
 
-if [[ "$FILES" != "" ]]; then
-    PREVIEW_LIBS="$FILES"
-else
-    PREVIEW_LIBS="Shapes2d Shapes3d Transforms Distributors Mutators Attachments Paths FractalTree"
+if (( ${#FILES[@]} == 0 )); then
+    FILES=(Shapes2d Shapes3d Transforms Distributors Mutators Attachments Paths FractalTree)
 fi
 
-dir="$(basename $PWD)"
-if [ "$dir" = "BOSL2" ]; then
-    cd BOSL2.wiki
-elif [ "$dir" != "BOSL2.wiki" ]; then
-    echo "Must run this script from the BOSL2 or BOSL2/BOSL2.wiki directories."
+# Try to cd to the BOSL2.wiki directory if run from the BOSL2 root
+if [[ "$(basename "$PWD")" != "BOSL2.wiki" ]]; then
+  if ! cd BOSL2.wiki; then
+    echo "BOSL2.wiki directory not found, try running from the BOSL2 or BOSL2/BOSL2.wiki directory" >&2
     exit 1
+  fi
 fi
 
 rm -f tmp_*.scad
-for base in $PREVIEW_LIBS; do
-    base="$(basename $base .md)"
+for base in "${FILES[@]}"; do
+    base="$(basename "$base" .md)"
     mkdir -p images/tutorials
-    rm -f images/tutorials/${base}_*.png images/tutorials/${base}_*.gif
-    echo "$base.md"
-    ../scripts/tutorial_gen.py ../tutorials/$base.md -o Tutorial-$base.md $FORCED -I images/tutorials/ || exit 1
-    if [ "$DISPMD" != "" ]; then
-        open -a Typora Tutorial-$base.md
+    rm -f "images/tutorials/${base}"_*.png "images/tutorials/${base}"_*.gif
+    echo "${base}.md"
+    ../scripts/tutorial_gen.py "../tutorials/${base}.md" -o "Tutorial-${base}.md" "${GEN_ARGS[@]}" -I images/tutorials/ || exit 1
+    if (( DISPMD )); then
+        open -a Typora "Tutorial-${base}.md"
     fi
 done
 

--- a/scripts/purge_wiki_history.sh
+++ b/scripts/purge_wiki_history.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 if [[ ! -d BOSL2.wiki/.git ]] ; then
-	echo "Must be run from the BOSL2 directory, with the BOSL2.wiki repo inside."
-	exit -1
+	echo "Must be run from above the BOSL2.wiki repo." >&2
+	exit 1
 fi
 
+set -e # short-circuit if any command fails
 cd BOSL2.wiki
 rm -rf .git
 git init
@@ -12,5 +13,3 @@ git add .
 git commit -m "Purged wiki history."
 git remote add origin git@github.com:revarbat/BOSL2.wiki.git
 git push -u --force origin master
-cd ..
-

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,35 +1,31 @@
 #!/bin/bash
 
-if [ "$(uname -s)" != "Darwin" ]; then
-    OPENSCAD=openscad
-else
+OPENSCAD=openscad
+if [ "$(uname -s)" == "Darwin" ]; then
     OPENSCAD=/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD
 fi
 
-if [ "$*" != "" ] ; then
-    INFILES="$*"
-else
-    INFILES="tests/test_*.scad"
+INFILES=("$@")
+if (( ${#INFILES[@]} == 0 )); then
+    INFILES=(tests/test_*.scad)
 fi
 
 OUTCODE=0
-for testscript in $INFILES ; do
-    repname="$(basename $testscript | sed 's/^test_//')"
-    testfile="tests/test_$repname"
-    if [ -f "$testfile" ] ; then
-        ${OPENSCAD} -o out.echo --hardwarnings --check-parameters true --check-parameter-ranges true $testfile 2>&1
+for testfile in "${INFILES[@]}"; do
+    if [[ -f "$testfile" ]] ; then
+        repname="$(basename "$testfile" | sed 's/^test_//')"
+        "${OPENSCAD}" -o out.echo --hardwarnings --check-parameters true --check-parameter-ranges true "$testfile" 2>&1
         retcode=$?
-        res=$(cat out.echo)
-        if [ $retcode -eq 0 ] && [ "$res" = "" ] ; then
+        output=$(cat out.echo)
+        if (( retcode == 0 )) && [[ "$output" = "" ]]; then
             echo "$repname: PASS"
         else
             echo "$repname: FAIL!"
-            cat out.echo
-            echo
-            OUTCODE=-1
+            echo "$output"
+            OUTCODE="$retcode"
         fi
         rm -f out.echo
     fi
 done
-exit $OUTCODE
+exit "$OUTCODE"
 


### PR DESCRIPTION
* Fixed ShellCheck.net warnings, including
  * exit -1: https://github.com/koalaman/shellcheck/wiki/SC2242
  * cd || exit: https://github.com/koalaman/shellcheck/wiki/SC2164
  * "$foo": https://github.com/koalaman/shellcheck/wiki/SC2086
  * $(( $foo )): https://github.com/koalaman/shellcheck/wiki/SC2004
  * grep | wc -l: https://github.com/koalaman/shellcheck/wiki/SC2126
* Use arrays instead of unquoted strings for loops and command arguments
* Use (( ... )) arithmetic context instead of string comparisons
* Use bash's built-in regex support instead of grep+sed+awk
* Write errors to stderr