### PR TITLE
Match affine3d skews {_xy, _xz, _yz} up to affine2d_skew behaviour

### DIFF
--- a/affine.scad
+++ b/affine.scad
@@ -519,10 +519,10 @@ function affine3d_skew_xy(xa=0, ya=0) =
     assert(is_finite(xa))
     assert(is_finite(ya))
     [
-        [1, 0, tan(xa), 0],
-        [0, 1, tan(ya), 0],
-        [0, 0,       1, 0],
-        [0, 0,       0, 1]
+        [      1, tan(xa), 0, 0],
+        [tan(ya),       1, 0, 0],
+        [      0,       0, 1, 0],
+        [      0,       0, 0, 1]
     ];
 
 
@@ -551,10 +551,10 @@ function affine3d_skew_xz(xa=0, za=0) =
     assert(is_finite(xa))
     assert(is_finite(za))
     [
-        [1, tan(xa), 0, 0],
-        [0,       1, 0, 0],
-        [0, tan(za), 1, 0],
-        [0,       0, 0, 1]
+        [      1, 0, tan(xa), 0],
+        [      0, 1,       0, 0],
+        [tan(za), 0,       1, 0],
+        [      0, 0,       0, 1]
     ];
 
 
@@ -583,10 +583,10 @@ function affine3d_skew_yz(ya=0, za=0) =
     assert(is_finite(ya))
     assert(is_finite(za))
     [
-        [      1, 0, 0, 0],
-        [tan(ya), 1, 0, 0],
-        [tan(za), 0, 1, 0],
-        [      0, 0, 0, 1]
+        [1,       0,       0, 0],
+        [0,       1, tan(ya), 0],
+        [0, tan(za),       1, 0],
+        [0,       0,       0, 1]
     ];
 
 

--- a/tests/test_affine.scad
+++ b/tests/test_affine.scad
@@ -137,7 +137,7 @@ test_affine3d_skew();
 module test_affine3d_skew_xy() {
     for(ya = [-89:3:89]) {
         for(xa = [-89:3:89]) {
-            assert(affine3d_skew_xy(xa=xa, ya=ya) == [[1,0,tan(xa),0],[0,1,tan(ya),0],[0,0,1,0],[0,0,0,1]]);
+            assert(affine3d_skew_xy(xa=xa, ya=ya) == [[1,tan(xa),0,0],[tan(ya),1,0,0],[0,0,1,0],[0,0,0,1]]);
         }
     }
 }
@@ -147,7 +147,7 @@ test_affine3d_skew_xy();
 module test_affine3d_skew_xz() {
     for(za = [-89:3:89]) {
         for(xa = [-89:3:89]) {
-            assert(affine3d_skew_xz(xa=xa, za=za) == [[1,tan(xa),0,0],[0,1,0,0],[0,tan(za),1,0],[0,0,0,1]]);
+            assert(affine3d_skew_xz(xa=xa, za=za) == [[1,0,tan(xa),0],[0,1,0,0],[tan(za),0,1,0],[0,0,0,1]]);
         }
     }
 }
@@ -157,7 +157,7 @@ test_affine3d_skew_xz();
 module test_affine3d_skew_yz() {
     for(za = [-89:3:89]) {
         for(ya = [-89:3:89]) {
-            assert(affine3d_skew_yz(ya=ya, za=za) == [[1,0,0,0],[tan(ya),1,0,0],[tan(za),0,1,0],[0,0,0,1]]);
+            assert(affine3d_skew_yz(ya=ya, za=za) == [[1,0,0,0],[0,1,tan(ya),0],[0,tan(za),1,0],[0,0,0,1]]);
         }
     }
 }


### PR DESCRIPTION
Currently, affine2d_skew and affine3d_skew_xy have different behaviour.

```openscad
include <BOSL2/std.scad>

sq = square(10, center=true);
m2 = affine2d_skew(45, 0);
m3 = affine3d_skew_xy(45, 0);

linear_extrude(1) polygon(apply(m2, sq));

translate([0, 0, 5])
    multmatrix(m3)
        linear_extrude(1) 
            polygon(sq);
```

![bosl2_skew_mismatch](https://user-images.githubusercontent.com/14910691/183269784-22a51ba6-7148-491a-8372-146abc0bcc17.png)

Similarly, affine3d_skew_xz and affine3d_skew_yz do not skew the same
way as affine2d_skew does (if you were to look down the third axis at
the relevant plane), though I think that they *should* be based on the documentation (as in, skewing along the plane corresponding to the arguments). 

With these changes, the code above now provides similar results for 2d and 3d xy skewing:

![bosl2_skew_fix](https://user-images.githubusercontent.com/14910691/183269780-09fd6394-45b2-4c29-a28a-a31c952cf8a8.png)

Apologies if I've misunderstood something, but I thought I should submit a patch in case.