### PR TITLE
Fix "linear_sweep(..., texture=..., scale=..., twist=...)".

### DIFF
--- a/skin.scad
+++ b/skin.scad
@@ -3489,8 +3489,8 @@ function _textured_linear_sweep(
                                     if (i != counts.y || ti == 0)
                                     let(
                                         v = (i + (ti/texcnt.y)) / counts.y,
-                                        sc = lerp(scale, [1,1,1], v),
-                                        mat = down((v-0.5)*h) *
+                                        sc = lerp([1, 1, 1], scale, v),
+                                        mat = up((v-0.5)*h) *
                                               scale(sc) *
                                               zrot(twist*v)
                                     ) apply(mat, tile_rows[ti])


### PR DESCRIPTION
The commit 'Fix "linear_sweep(..., texture=..., scale=...)" was not enough.  This one fixes linear_sweep(..., texture=...) when scale and/or twist parameters are specified.

Code to reproduce the fixed issue:

  linear_sweep(ellipse(d = [5, 10]), 5, twist = 45, texture = "bricks", scale = 0.5);