### PR TITLE
Fix BOSL2logo.scad: tag syntax changed

### DIFF
--- a/examples/BOSL2logo.scad
+++ b/examples/BOSL2logo.scad
@@ -11,11 +11,11 @@ xdistribute(50) {
 	recolor("#f77")
 	diff("hole")
 	cuboid([45,45,10], chamfer=10, edges=[RIGHT+BACK,RIGHT+FRONT], anchor=FRONT) {
-		cuboid([30,30,11], chamfer=5, edges=[RIGHT+BACK,RIGHT+FRONT], $tags="hole");
+		tag("hole")cuboid([30,30,11], chamfer=5, edges=[RIGHT+BACK,RIGHT+FRONT]);
 		attach(FRONT,BACK, overlap=5) {
-			diff("hole")
+			diff("hole2")
 			cuboid([45,45,10], rounding=15, edges=[RIGHT+BACK,RIGHT+FRONT]) {
-				cuboid([30,30,11], rounding=10, edges=[RIGHT+BACK,RIGHT+FRONT], $tags="hole");
+				tag("hole2")cuboid([30,30,11], rounding=10, edges=[RIGHT+BACK,RIGHT+FRONT]);
 			}
 		}
 	}
@@ -50,4 +50,3 @@ xdistribute(50) {
 				nut("M12", thickness=10, diameter=20);
 	}
 }
-


### PR DESCRIPTION
See [fixed version](https://ochafik.com/openscad2/#%7B%22params%22%3A%7B%22sourcePath%22%3A%22%2Fhome%2Fplayground.scad%22%2C%22source%22%3A%22include%20%3CBOSL2%2Fstd.scad%3E%5Cninclude%20%3CBOSL2%2Fgears.scad%3E%5Cninclude%20%3CBOSL2%2Fbeziers.scad%3E%5Cninclude%20%3CBOSL2%2Fscrews.scad%3E%5Cninclude%20%3CBOSL2%2Fcubetruss.scad%3E%5Cn%5Cn%24fa%3D1%3B%5Cn%24fs%3D1%3B%5Cn%5Cnxdistribute(50)%20%7B%5Cn%5Ctrecolor(%5C%22%23f77%5C%22)%5Cn%5Ctdiff(%5C%22hole%5C%22)%5Cn%5Ctcuboid(%5B45%2C45%2C10%5D%2C%20chamfer%3D10%2C%20edges%3D%5BRIGHT%2BBACK%2CRIGHT%2BFRONT%5D%2C%20anchor%3DFRONT)%20%7B%5Cn%5Ct%5Cttag(%5C%22hole%5C%22)cuboid(%5B30%2C30%2C11%5D%2C%20chamfer%3D5%2C%20edges%3D%5BRIGHT%2BBACK%2CRIGHT%2BFRONT%5D)%3B%5Cn%5Ct%5Ctattach(FRONT%2CBACK%2C%20overlap%3D5)%20%7B%5Cn%5Ct%5Ct%5Ctdiff(%5C%22hole2%5C%22)%5Cn%5Ct%5Ct%5Ctcuboid(%5B45%2C45%2C10%5D%2C%20rounding%3D15%2C%20edges%3D%5BRIGHT%2BBACK%2CRIGHT%2BFRONT%5D)%20%7B%5Cn%5Ct%5Ct%5Ct%5Cttag(%5C%22hole2%5C%22)cuboid(%5B30%2C30%2C11%5D%2C%20rounding%3D10%2C%20edges%3D%5BRIGHT%2BBACK%2CRIGHT%2BFRONT%5D)%3B%5Cn%5Ct%5Ct%5Ct%7D%5Cn%5Ct%5Ct%7D%5Cn%5Ct%7D%5Cn%5Cn%20%20%20%20recolor(%5C%22%237f7%5C%22)%5Cn%5Ctbevel_gear(pitch%3D8%2C%20teeth%3D20%2C%20face_width%3D12%2C%20shaft_diam%3D25%2C%20pitch_angle%3D45%2C%20slices%3D12%2C%20spiral_angle%3D30)%3B%5Cn%5Cn%5Ctx%20%3D%2018%3B%5Cn%5Cty%20%3D%2020%3B%5Cn%5Cts1%20%3D%2025%3B%5Cn%5Cts2%20%3D%2020%3B%5Cn%5Ctsbez%20%3D%20%5B%5Cn%5Ct%5Ct%20%20%20%20%20%20%20%20%20%20%20%20%5B-x%2C-y%5D%2C%20%5B-x%2C-y-s1%5D%2C%5Cn%5Ct%5Ct%5B%20x%2C-y-s1%5D%2C%20%5B%20x%2C-y%5D%2C%20%5B%20x%2C-y%2Bs2%5D%2C%5Cn%5Ct%5Ct%5B-x%2C%20y-s2%5D%2C%20%5B-x%2C%20y%5D%2C%20%5B-x%2C%20y%2Bs1%5D%2C%5Cn%5Ct%5Ct%5B%20x%2C%20y%2Bs1%5D%2C%20%5B%20x%2C%20y%5D%5Cn%5Ct%5D%3B%5Cn%5Ctrecolor(%5C%22%2399f%5C%22)%5Cn%5Ctpath_sweep(regular_ngon(n%3D3%2Cd%3D10%2Cspin%3D90)%2C%20bezpath_curve(sbez))%3B%5Cn%5Cn%5Ctrecolor(%5C%22%230bf%5C%22)%5Cn%5Cttranslate(%5B-15%2C-35%2C0%5D)%5Cn%5Ctcubetruss_corner(size%3D10%2C%20strut%3D1%2C%20h%3D1%2C%20bracing%3Dfalse%2C%20extents%3D%5B3%2C8%2C0%2C0%2C0%5D%2C%20clipthick%3D0)%3B%5Cn%5Cn%5Ctrecolor(%5C%22%23777%5C%22)%5Cn%5Ctxdistribute(24)%20%7B%5Cn%5Ct%5Ctscrew(%5C%22M12%2C70%5C%22%2C%20head%3D%5C%22hex%5C%22%2C%20anchor%3D%5C%22origin%5C%22%2C%20orient%3DBACK)%5Cn%5Ct%5Ct%5Ctattach(BOT%2CCENTER)%5Cn%5Ct%5Ct%5Ct%5Ctnut(%5C%22M12%5C%22%2C%20thickness%3D10%2C%20diameter%3D20)%3B%5Cn%5Ct%5Ctscrew(%5C%22M12%2C70%5C%22%2C%20head%3D%5C%22hex%5C%22%2C%20anchor%3D%5C%22origin%5C%22%2C%20orient%3DBACK)%5Cn%5Ct%5Ct%5Ctattach(BOT%2CCENTER)%5Cn%5Ct%5Ct%5Ct%5Ctnut(%5C%22M12%5C%22%2C%20thickness%3D10%2C%20diameter%3D20)%3B%5Cn%5Ct%7D%5Cn%7D%5Cn%22%2C%22features%22%3A%5B%22manifold%22%2C%22fast-csg%22%2C%22lazy-union%22%5D%7D%2C%22view%22%3A%7B%22layout%22%3A%7B%22mode%22%3A%22multi%22%2C%22focus%22%3Afalse%2C%22editor%22%3Atrue%2C%22viewer%22%3Atrue%2C%22customizer%22%3Afalse%7D%2C%22logs%22%3Atrue%7D%7D) in playground 