### PR TITLE
Implement a zip() function to iterate over lists in parallel

### DIFF
--- a/lists.scad
+++ b/lists.scad
@@ -1074,6 +1074,30 @@ function full_flatten(l) =
     [for (a=l) if (is_list(a)) (each full_flatten(a)) else a];
 
 
+// Function: zip()
+// Synopsis: Group elements from multiple lists by index.
+// Topics: List Handling, Iteration
+// See Also: pair(), triplet(), transpose()
+// Usage:
+//   list = zip(lists);
+//   list = zip(LIST1,LIST2);
+// Description:
+//   Returns a list composed of elements from the given lists. Each entry in the new list is composed of elements at that corresponding index from each input. If any list run out of elements before others, "undef" will be used.
+//   The primary use case is iterating over elements from two lists in pairs. It can also be used to transpose a matrix.
+// Arguments:
+//   lists = List of lists to iterate over
+// Example:
+//   l1 = zip([1,2,3],["A","B","C"]);        // returns [[1,"A"],[2,"B"],[3,"C"]]
+//   l2 = zip([[0,1,2],[-1,0,1],[-2,-1,0]]); // returns [[0,-1,-2],[1,0,-1],[2,1,0]]
+// Example(2D):
+//   p = circle(20,$fn=13);
+//   for(c=zip(p,path_normals(p,closed=true)))
+//        stroke([c[0],c[0]-c[1]*10],endcap2="arrow2");
+function zip(lists,l1=undef) =
+    !is_undef(l1) ? zip([lists,l1]) :
+    assert(all(lists,function(l) is_list(l)),"every argument must be a list")
+    lists ? [for(i=[0:max_length(lists)-1]) [for(l=lists) l[i]]] : [];
+
 
 // Section: Set Manipulation
 

--- a/tests/test_lists.scad
+++ b/tests/test_lists.scad
@@ -409,6 +409,17 @@ module test_full_flatten() {
 test_full_flatten();
 
 
+module test_zip() {
+    assert(zip([])==[]);
+    assert(zip([1,2,3],["A","B","C"])==[[1,"A"],[2,"B"],[3,"C"]]);
+    assert(zip([[0,1,2],[-1,0,1],[-2,-1,0]])==[[0,-1,-2],[1,0,-1],[2,1,0]]);
+    assert(zip([[1,2,3]])==[[1],[2],[3]]);
+    assert(zip([[1,2,3],[4,5],[6],[]])==[[1,4,6,undef],[2,5,undef,undef],[3,undef,undef,undef]]);
+    assert(zip(zip([1,2,3],[4,5,6]))==[[1,2,3],[4,5,6]]);
+}
+test_zip();
+
+
 module test_list_shape() {
     assert(list_shape([[[1,2,3],[4,5,6]],[[7,8,9],[10,11,12]]]) == [2,2,3]);
     assert(list_shape([[[1,2,3],[4,5,6]],[[7,8,9],[10,11,12]]], 0) == 2);


### PR DESCRIPTION
I missed a `zip()` function in BOSL2 (at least I couldn't find one), and implemented one as an exercise in writing test code and documentation.

`zip(a,b)` takes items from lists _a_ and _b_ in parallel and can be used for things such as processing a path and its tangents. `zip(a,b) == [ [a[0],b[0]], [a[1],b[1]], ... ]`

The weird name _zip_ comes from the same function in python, perl, C++ and others. I don't like it, but that's common usage now.

The already existing `transpose()` can be used to do this for some lists, but is really tailored for matrices and doesn't like empty lists and uneven lengths etc.
