### PR TITLE
Add daily version stamp workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/version_stamp.yml
+++ b/.github/workflows/version_stamp.yml
@@ -1,0 +1,54 @@
+name: Daily Version Stamp
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  version-stamp:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Check for changes in the previous day
+      id: check_changes
+      run: |
+        YESTERDAY=$(date -u -d "yesterday" +%Y-%m-%d)
+        TODAY=$(date -u +%Y-%m-%d)
+
+        # Count commits on master from the previous day, excluding bot version-stamp commits
+        COMMIT_COUNT=$(git log --oneline --after="${YESTERDAY}T00:00:00Z" --before="${TODAY}T00:00:00Z" --first-parent origin/master --invert-grep --author="github-actions\[bot\]" | wc -l)
+
+        echo "Checking for commits on ${YESTERDAY}: found ${COMMIT_COUNT}"
+
+        if [ "$COMMIT_COUNT" -gt 0 ]; then
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Increment version
+      if: steps.check_changes.outputs.has_changes == 'true'
+      id: version
+      run: |
+        ./scripts/increment_version.sh
+        NEW_VERSION=$(grep -oP 'BOSL_VERSION = \[\K[0-9]+,[0-9]+,[0-9]+' version.scad | tr ',' '.')
+        echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Commit and push
+      if: steps.check_changes.outputs.has_changes == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add version.scad
+        git commit -m "Version bump to v${{ steps.version.outputs.new_version }}"
+        git tag "v${{ steps.version.outputs.new_version }}"
+        git push origin master "v${{ steps.version.outputs.new_version }}"
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BOSL2 (Belfry OpenSCAD Library v2) is a comprehensive OpenSCAD library providing modeling tools, transformations, shapes, attachments, and parts. It requires OpenSCAD 2021.01 or later. The library is in beta status.
+
+## Common Commands
+
+### Running Tests
+
+Run all regression tests:
+```bash
+./scripts/run_tests.sh
+```
+
+Run a single test file:
+```bash
+./scripts/run_tests.sh tests/test_shapes3d.scad
+```
+
+On macOS, the test runner uses `/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD`. On Linux, it uses `openscad` from PATH.
+
+Tests pass when OpenSCAD exits with code 0 and produces no output. Any output or non-zero exit indicates failure.
+
+### Checking for Tabs
+
+```bash
+./scripts/check_for_tabs.sh
+```
+All `.scad` files must use spaces only (no tabs). Indentation: 4 spaces.
+
+### Documentation Validation
+
+Requires the `openscad-docsgen` Python package (`pip install openscad-docsgen`):
+```bash
+openscad-docsgen -Tmf
+```
+
+### Function Coverage Analysis
+
+```bash
+python3 scripts/func_coverage.py
+```
+
+## Architecture
+
+### Entry Point and Dependency Order
+
+`std.scad` is the main include file. Users write `include <BOSL2/std.scad>` to get the standard library. It includes files in a specific dependency order:
+
+`version` → `constants` → `transforms` → `distributors` → `miscellaneous` → `color` → `attachments` → `beziers` → `shapes3d` → `shapes2d` → `drawing` → `masks` → `math` → `paths` → `lists` → `comparisons` → `linalg` → `trigonometry` → `vectors` → `affine` → `coords` → `geometry` → `regions` → `strings` → `vnf` → `structs` → `rounding` → `skin` → `utility` → `partitions`
+
+Specialized modules (gears, screws, threading, hinges, etc.) are **not** included by `std.scad` and must be included separately by users.
+
+### Key Subsystems
+
+- **Attachment system** (`attachments.scad`): Core mechanism for positioning children relative to parents using anchor points, without manual coordinate tracking. Most shapes support `anchor`, `spin`, and `orient` parameters.
+- **VNF** (`vnf.scad`): Vertices 'N' Faces representation for polyhedra manipulation. Many functions can return VNF data via function form.
+- **Paths/Regions** (`paths.scad`, `regions.scad`): 2D point-list operations for curves and polygon regions.
+- **Skinning/Sweeping** (`skin.scad`): Creates 3D objects by sweeping profiles along paths.
+- **Rounding** (`rounding.scad`): Edge rounding, filleting, and offset_sweep operations.
+
+### Dual Function/Module Pattern
+
+Many BOSL2 items exist as both OpenSCAD functions and modules (documented as `Function&Module`). The function form returns data (VNF, path, matrix), while the module form creates geometry. Example: `cube()` as a module creates a shape; as a function it returns a VNF.
+
+### Include Guard Pattern
+
+Each file has a guard at the top that warns if included without `std.scad`:
+```openscad
+_BOSL2_FILENAME = is_undef(_BOSL2_STD) && ... ?
+    echo("Warning: filename.scad included without std.scad") true : true;
+```
+
+## Writing Tests
+
+Test files go in `tests/` named `test_<module>.scad`. Pattern:
+```openscad
+include <../std.scad>
+
+module test_function_name() {
+    assert(function_name(args) == expected);
+}
+test_function_name();
+```
+
+Each test is a module containing `assert()` calls, immediately invoked after definition. Tests must produce zero output to pass.
+
+## Documentation Format
+
+Every public function/module must have documentation comments following the custom block syntax parsed by `openscad-docsgen`. Required blocks:
+
+```openscad
+// Function&Module: name()
+// Synopsis: One-line summary.
+// Topics: Topic1, Topic2
+// See Also: related_func()
+// Usage: As Module
+//   name(arg1, arg2);
+// Usage: As Function
+//   result = name(arg1, arg2);
+// Description:
+//   Detailed description. Supports markdown.
+//   Link to other items with {{other_func()}} syntax.
+// Arguments:
+//   arg1 = Description of arg1
+//   arg2 = Description of arg2
+// Example:
+//   name(10, 20);
+```
+
+See `WRITING_DOCS.md` for the full documentation syntax reference. Configuration is in `.openscad_docsgen_rc`.
+
+## Code Conventions
+
+- Private functions/modules: prefix with underscore (`_helper_func()`)
+- Public names: lowercase with underscores
+- Constants: UPPERCASE (`UP`, `DOWN`, `LEFT`, `RIGHT`, `FRONT`, `BACK`)
+- Special variables use `$` prefix (`$slop`, `$fn`)
+- Files end with: `// vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap`
+- No tabs in `.scad` files; use 4-space indentation
+
+## CI Pipeline
+
+Pull requests run three checks:
+1. **Regressions**: Runs `scripts/run_tests.sh`
+2. **CheckTutorials**: Validates tutorial markdown and images
+3. **CheckDocs**: Validates all documentation blocks with `openscad-docsgen -Tmf`


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/version_stamp.yml`) that runs at midnight UTC daily, checks if master had any non-bot commits the previous day, and if so runs `scripts/increment_version.sh` to bump the revision, tags the commit, and pushes both to master
- Add `CLAUDE.md` with project guidance for Claude Code

## Test plan
- [ ] Verify workflow syntax is valid by triggering manually via `workflow_dispatch`
- [ ] Confirm version bump, tag creation, and push work correctly on a test run
- [ ] Confirm bot commits are excluded from the change detection to avoid cascading bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)