### PR TITLE
Simplify version stamp trigger to check latest commit

### DIFF
--- a/.github/workflows/version_stamp.yml
+++ b/.github/workflows/version_stamp.yml
@@ -17,23 +17,13 @@ jobs:
         ref: master
         fetch-depth: 0
 
-    - name: Check for changes since last version bump
+    - name: Check if latest commit is a merged PR
       id: check_changes
       run: |
-        # Find the most recent version bump commit by this bot
-        LAST_BUMP=$(git log --first-parent origin/master --author="github-actions\[bot\]" --grep="Version bump to" --format="%H" -1)
+        LATEST_MSG=$(git log --first-parent origin/master --format="%s" -1)
+        echo "Latest commit: ${LATEST_MSG}"
 
-        if [ -n "$LAST_BUMP" ]; then
-          # Count non-bot commits since the last version bump
-          COMMIT_COUNT=$(git log --oneline --first-parent origin/master "${LAST_BUMP}..HEAD" --invert-grep --author="github-actions\[bot\]" | wc -l)
-          echo "Commits since last version bump (${LAST_BUMP:0:8}): ${COMMIT_COUNT}"
-        else
-          # No previous version bump found; count all non-bot commits
-          COMMIT_COUNT=$(git log --oneline --first-parent origin/master --invert-grep --author="github-actions\[bot\]" | wc -l)
-          echo "No previous version bump found. Total non-bot commits: ${COMMIT_COUNT}"
-        fi
-
-        if [ "$COMMIT_COUNT" -gt 0 ]; then
+        if echo "$LATEST_MSG" | grep -q "^Merged pull request #"; then
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "has_changes=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Replaces the date-based change detection with a simpler check: only bump the version if the latest commit on master starts with "Merged pull request #"
- This avoids missed bumps if the workflow fails to run on a given day, since the merge commit remains as the latest until the bump replaces it

## Test plan
- [ ] Trigger manually via `workflow_dispatch` when latest master commit is a merged PR — should bump version and tag
- [ ] Trigger manually when latest master commit is a version bump — should skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)