### PR TITLE
Fix merge commit pattern in version stamp workflow

### DIFF
--- a/.github/workflows/version_stamp.yml
+++ b/.github/workflows/version_stamp.yml
@@ -23,7 +23,7 @@ jobs:
         LATEST_MSG=$(git log --first-parent origin/master --format="%s" -1)
         echo "Latest commit: ${LATEST_MSG}"
 
-        if echo "$LATEST_MSG" | grep -q "^Merged pull request #"; then
+        if echo "$LATEST_MSG" | grep -q "^Merge pull request #"; then
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "has_changes=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix grep pattern: GitHub uses "Merge pull request #" not "Merged pull request #"
- Confirmed by manual workflow trigger that showed the latest commit as `Merge pull request #1912 from BelfrySCAD/revarbat_dev` but failed to match

## Test plan
- [ ] Merge this PR, then trigger `version_stamp.yml` manually via `workflow_dispatch`
- [ ] Verify the version is bumped, tagged, and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)