### PR TITLE
Fix weekly release when notes exceed size limit

### DIFF
--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -49,6 +49,8 @@ jobs:
       if: steps.find_tag.outputs.has_tag == 'true' && steps.check_release.outputs.exists == 'false'
       run: |
         TAG="${{ steps.find_tag.outputs.tag }}"
-        gh release create "$TAG" --title "$TAG" --generate-notes
+        # Try with auto-generated notes; fall back to simple notes if body is too long
+        gh release create "$TAG" --title "$TAG" --generate-notes || \
+          gh release create "$TAG" --title "$TAG" --notes "Release ${TAG}"
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Fall back to simple release notes when GitHub's auto-generated notes exceed the 125K character limit
- This happened on the first run since there was no previous release, so the entire project history was included

## Test plan
- [ ] Trigger `weekly_release.yml` manually after merge to verify release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)