### PR TITLE
Skip version bump when all changes are comment-only

### DIFF
--- a/.github/workflows/version_stamp.yml
+++ b/.github/workflows/version_stamp.yml
@@ -29,8 +29,43 @@ jobs:
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Increment version
+    - name: Check if changes are comment-only since last version bump
+      id: check_comments
       if: steps.check_changes.outputs.has_changes == 'true'
+      run: |
+        LAST_BUMP=$(git log --first-parent origin/master --format="%H %s" | grep " Version bump to v" | head -1 | awk '{print $1}')
+        echo "Last version bump commit: ${LAST_BUMP}"
+
+        if [ -z "$LAST_BUMP" ]; then
+          echo "No previous version bump found; treating as having real changes."
+          echo "only_comments=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Get all added/removed lines since last version bump, excluding version.scad
+        CHANGED_LINES=$(git diff "${LAST_BUMP}"..origin/master -- ':!version.scad' \
+          | grep -E '^[+-]' \
+          | grep -Ev '^(\+\+\+|---)')
+
+        if [ -z "$CHANGED_LINES" ]; then
+          echo "No non-version changes found."
+          echo "only_comments=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Strip leading +/- and check for any non-comment, non-blank lines
+        NON_COMMENT=$(echo "$CHANGED_LINES" | sed 's/^[+-]//' | grep -Ev '^[[:space:]]*//' | grep -Ev '^[[:space:]]*$')
+
+        if [ -z "$NON_COMMENT" ]; then
+          echo "All changes are comment-only; skipping version bump."
+          echo "only_comments=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Real code changes detected; proceeding with version bump."
+          echo "only_comments=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Increment version
+      if: steps.check_changes.outputs.has_changes == 'true' && steps.check_comments.outputs.only_comments != 'true'
       id: version
       run: |
         ./scripts/increment_version.sh
@@ -38,7 +73,7 @@ jobs:
         echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Commit and push
-      if: steps.check_changes.outputs.has_changes == 'true'
+      if: steps.check_changes.outputs.has_changes == 'true' && steps.check_comments.outputs.only_comments != 'true'
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Adds a new step to the Daily Version Stamp workflow that checks whether all changes since the last version bump are limited to `//` comment lines
- If every changed line (excluding `version.scad`) is a comment or blank, the version bump and commit are skipped
- Handles edge cases: no previous bump found (proceeds with bump), no non-version changes found (skips bump)

## Test plan

- [ ] Merge a PR that only changes `//` comment lines in `.scad` files — verify the daily workflow does **not** bump the version
- [ ] Merge a PR with real code changes — verify the daily workflow **does** bump the version as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)