### PR TITLE
test: add regression tests for list_swap, swap_columns, lu_factor

### DIFF
--- a/tests/test_linalg.scadtest
+++ b/tests/test_linalg.scadtest
@@ -563,3 +563,21 @@ module test_echo_matrix() {
 }
 test_echo_matrix();
 '''
+
+[[test]]
+name = "test_swap_columns"
+script = '''
+include <../std.scad>
+
+module test_swap_columns() {
+    M = [[1,2,3,0,1],[4,5,6,0,1],[7,8,9,0,1]];
+    assert_equal(swap_columns(M, 1, 3), [[1,0,3,2,1],[4,0,6,5,1],[7,0,9,8,1]]);
+    assert_equal(swap_columns(M, 0, 4), [[1,2,3,0,1],[1,5,6,0,4],[1,8,9,0,7]]);
+    assert_equal(swap_columns(M, 2, 2), M);
+    N = [[1,2],[3,4]];
+    assert_equal(swap_columns(N, 0, 1), [[2,1],[4,3]]);
+    I = ident(3);
+    assert_equal(swap_columns(I, 0, 2), [[0,0,1],[0,1,0],[1,0,0]]);
+}
+test_swap_columns();
+'''

--- a/tests/test_linalg.scadtest
+++ b/tests/test_linalg.scadtest
@@ -581,3 +581,46 @@ module test_swap_columns() {
 }
 test_swap_columns();
 '''
+
+[[test]]
+name = "test_lu_factor"
+script = '''
+include <../std.scad>
+
+module test_lu_factor() {
+    A = [[2, 1], [5, 3]];
+    lup = lu_factor(A);
+    assert(is_list(lup));
+    assert(len(lup) == 3);
+    LT = lup[0];
+    U = lup[1];
+    perm = lup[2];
+    reconstructed = select(A, perm);
+    product = transpose(LT) * U;
+    for(i=[0:len(A)-1])
+        for(j=[0:len(A[0])-1])
+            assert_approx(product[i][j], reconstructed[i][j]);
+    B = [[1,2,3],[4,5,6],[7,8,10]];
+    lup2 = lu_factor(B);
+    assert(is_list(lup2));
+    LT2 = lup2[0];
+    U2 = lup2[1];
+    perm2 = lup2[2];
+    reconstructed2 = select(B, perm2);
+    product2 = transpose(LT2) * U2;
+    for(i=[0:len(B)-1])
+        for(j=[0:len(B[0])-1])
+            assert_approx(product2[i][j], reconstructed2[i][j]);
+    I = ident(3);
+    lup3 = lu_factor(I);
+    assert(is_list(lup3));
+    LT3 = lup3[0];
+    U3 = lup3[1];
+    perm3 = lup3[2];
+    product3 = transpose(LT3) * U3;
+    for(i=[0:2])
+        for(j=[0:2])
+            assert_approx(product3[i][j], I[i][j]);
+}
+test_lu_factor();
+'''

--- a/tests/test_lists.scadtest
+++ b/tests/test_lists.scadtest
@@ -652,3 +652,20 @@ module test_permutations() {
 }
 test_permutations();
 '''
+
+[[test]]
+name = "test_list_swap"
+script = '''
+include <../std.scad>
+
+module test_list_swap() {
+    assert_equal(list_swap([2,3,4,5], 0, 2), [4,3,2,5]);
+    assert_equal(list_swap([1,2,3,4,5], 1, 3), [1,4,3,2,5]);
+    assert_equal(list_swap([1,2,3], 0, 0), [1,2,3]);
+    assert_equal(list_swap(["a","b","c"], 0, 2), ["c","b","a"]);
+    assert_equal(list_swap([10,20,30,40], 0, 3), [40,20,30,10]);
+    assert_equal(list_swap([10,20,30,40], 3, 0), [40,20,30,10]);
+    assert_equal(list_swap([[1,2],[3,4],[5,6]], 0, 2), [[5,6],[3,4],[1,2]]);
+}
+test_list_swap();
+'''


### PR DESCRIPTION
## Summary
- Add regression test for `list_swap()` with 7 asserts covering basic swaps, same-index, strings, and nested lists
- Add regression test for `swap_columns()` with 5 asserts covering 2x2, 3x3, and identity matrices
- Add regression test for `lu_factor()` with reconstruction verification for 2x2, 3x3, and identity matrices
- Achieves 100% function test coverage (855/855, up from 99.65%)

## Test plan
- [x] All 3 test functions pass in OpenSCAD without errors
- [x] No ECHO output produced
- [x] Verified with `func_coverage.py` that coverage is now 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)